### PR TITLE
Small modifications,  fixed glitch in range query

### DIFF
--- a/config/LinkConfigMongoDBv2.properties
+++ b/config/LinkConfigMongoDBv2.properties
@@ -33,7 +33,7 @@ password =
 port = 27017
 # connection options are name=value{&name=value...}
 # See http://api.mongodb.org/java/3.0/com/mongodb/MongoClientURI.html for options
-connection_options = maxPoolSize=1
+connection_options = 
 # dbid: the database name to use
 dbid = graph-linkbench
 

--- a/src/main/java/com/percona/LinkBench/LinkStoreMongoDBv2.java
+++ b/src/main/java/com/percona/LinkBench/LinkStoreMongoDBv2.java
@@ -1152,8 +1152,10 @@ public class LinkStoreMongoDBv2 extends GraphStore {
     linkFind.put("id1", id1);
     linkFind.put("link_type", link_type);
     linkFind.put("visibility", LinkStore.VISIBILITY_DEFAULT);
-    linkFind.put("time", new BasicDBObject("$gte", minTimestamp));
-    linkFind.put("time", new BasicDBObject("$lte", maxTimestamp));
+    BasicDBObject timeRange=new BasicDBObject();
+    timeRange.put("$gte", minTimestamp);
+    timeRange.put("$lte", maxTimestamp);
+    linkFind.put("time", timeRange);
     
     DBCursor linkResult=linkColl.find(linkFind).
       sort(new BasicDBObject("time",-1)).

--- a/src/main/java/com/percona/LinkBench/LinkStoreMongoDBv2.java
+++ b/src/main/java/com/percona/LinkBench/LinkStoreMongoDBv2.java
@@ -1,17 +1,10 @@
 /*
- * Copyright 2012, Facebook, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * MongoDB driver for linkbench
+ * 
+ * Adapted from LinkStoreMysql.java
+ * 
+ * @author david.bennett at percona.com  (github.com/dbpercona)
+ * 
  */
 package com.percona.LinkBench;
 


### PR DESCRIPTION
- added MVCC transactions is supported to single document operations.
- Removed the option that disabled the connection pool from default MongoDB config
- fixed glitch in getLinkListImpl() range query.
