### PR TITLE
Removed request rate throttle from default MongoDB configuration.

### DIFF
--- a/config/LinkConfigMongoDBv2.properties
+++ b/config/LinkConfigMongoDBv2.properties
@@ -110,7 +110,7 @@ requests = 100000
 # request rate per thread.  <= 0 means unthrottled requests, > 0 limits
 #  the average request rate to that number of requests per second per thread,
 #  with the inter-request intervals governed by an exponential distribution
-requestrate = 500
+requestrate = 0
 
 # max duration in seconds for request phase of benchmark
 maxtime = 100000


### PR DESCRIPTION
Leave request rate throttle off for performance comparisons.
